### PR TITLE
obs: add Grafana API SLO dashboards and alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Production-oriented, küçük ama gerçekçi bir REST API örneği. Proje; güve
 - [DB kurulumu ve migration akışı](docs/db-migrations.md)
 - [Test workflow](docs/testing-workflow.md)
 - [Swagger / OpenAPI kullanımı](docs/api-swagger.md)
+- [API SLO dashboard ve alertler](docs/api-slo-dashboards.md)
 - [CI/CD failure runbook](docs/ci-debugging.md)
 
 ## Local Development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
       - "9091:9090"
     volumes:
       - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/prometheus/rules:/etc/prometheus/rules:ro
       - ./observability/data/prometheus:/prometheus
     restart: unless-stopped
     networks:

--- a/docs/api-slo-dashboards.md
+++ b/docs/api-slo-dashboards.md
@@ -1,0 +1,42 @@
+# API SLO Dashboards ve Alertler
+
+Bu dokuman, Grafana ve Prometheus tarafinda provision edilen API SLO dashboard ve alert kurallarini aciklar.
+
+## Dashboard
+
+- Dashboard UID: `api-slo-overview`
+- Provisioning yolu: `observability/grafana/provisioning/dashboards`
+- Dashboard klasoru: **API SLOs**
+
+Takip edilen temel sinyaller:
+
+- Availability (%) - son 5 dakikada 5xx olmayan istek oranindan hesaplanir
+- P95 latency (ms) - histogram quantile ile hesaplanir
+- 5xx error rate (%) - son 5 dakikadaki 5xx oranini gosterir
+- Throughput (req/s) - toplam API istek hizi
+- Route bazli latency trendi ve hata/istek serileri
+
+## SLO Tabanli Alert Kurallari
+
+Prometheus rule dosyasi: `observability/prometheus/rules/api-slo-rules.yml`
+
+- `ApiP95LatencyHigh` (warning): p95 latency > 300ms, 10 dakika
+- `ApiAvailabilityLow` (critical): availability < 99%, 10 dakika
+- `Api5xxErrorRateHigh` (warning): 5xx error rate > 1%, 10 dakika
+
+## Non-production Validation
+
+1. Stack'i kaldirin:
+
+```bash
+docker compose up --build -d
+```
+
+2. API trafigi uretin (normal + hatali istekler).
+3. Grafana'da `API SLO Overview` dashboard'unun otomatik geldigini dogrulayin.
+4. Prometheus'ta `Alerts` sayfasinda kurallarin yuklendiginin kontrolunu yapin.
+
+```bash
+curl http://localhost:9091/api/v1/rules
+curl http://localhost:9091/api/v1/alerts
+```

--- a/docs/run-observability.md
+++ b/docs/run-observability.md
@@ -16,6 +16,9 @@ docker compose ps
 - Prometheus: `http://localhost:9091`
 - PostgreSQL: `localhost:5432`
 
+Grafana, provisioning ile `API SLO Overview` dashboard'unu otomatik yukler.
+SLO panel ve alert detaylari icin: `docs/api-slo-dashboards.md`.
+
 ## Durdurma
 
 ```bash

--- a/observability/grafana/provisioning/dashboards/api-slo-overview.json
+++ b/observability/grafana/provisioning/dashboards/api-slo-overview.json
@@ -1,0 +1,167 @@
+{
+  "id": null,
+  "uid": "api-slo-overview",
+  "title": "API SLO Overview",
+  "tags": ["api", "slo", "prometheus"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Availability (5m)",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "((sum(rate(http_request_duration_ms_count{route=~\"/api/v1/.*\",status_code!~\"5..\"}[5m])) / sum(rate(http_request_duration_ms_count{route=~\"/api/v1/.*\"}[5m]))) * 100)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 99 },
+              { "color": "green", "value": 99.9 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "P95 Latency (ms, 5m)",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_ms_bucket{route=~\"/api/v1/.*\"}[5m])))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 200 },
+              { "color": "red", "value": 300 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "5xx Error Rate (5m)",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(sum(rate(http_request_duration_ms_count{route=~\"/api/v1/.*\",status_code=~\"5..\"}[5m])) / sum(rate(http_request_duration_ms_count{route=~\"/api/v1/.*\"}[5m]))) * 100"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Throughput (req/s, 5m)",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_request_duration_ms_count{route=~\"/api/v1/.*\"}[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "P95 Latency Trend by Route",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "{{route}}",
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_ms_bucket{route=~\"/api/v1/.*\"}[5m])))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Request Volume and 5xx Errors",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "total req/s",
+          "expr": "sum(rate(http_request_duration_ms_count{route=~\"/api/v1/.*\"}[5m]))"
+        },
+        {
+          "refId": "B",
+          "legendFormat": "5xx req/s",
+          "expr": "sum(rate(http_request_duration_ms_count{route=~\"/api/v1/.*\",status_code=~\"5..\"}[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: api-slo-dashboards
+    orgId: 1
+    folder: API SLOs
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -2,6 +2,9 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/rules/api-slo-rules.yml
+
 scrape_configs:
   - job_name: prometheus
     static_configs:

--- a/observability/prometheus/rules/api-slo-rules.yml
+++ b/observability/prometheus/rules/api-slo-rules.yml
@@ -1,0 +1,32 @@
+groups:
+  - name: api-slo-alerts
+    rules:
+      - alert: ApiP95LatencyHigh
+        expr: histogram_quantile(0.95, sum by (le) (rate(http_request_duration_ms_bucket{route=~"/api/v1/.*"}[5m]))) > 300
+        for: 10m
+        labels:
+          severity: warning
+          slo: latency
+        annotations:
+          summary: "API p95 latency is above 300ms"
+          description: "P95 latency for /api/v1 routes exceeded 300ms for 10 minutes."
+
+      - alert: ApiAvailabilityLow
+        expr: ((sum(rate(http_request_duration_ms_count{route=~"/api/v1/.*",status_code!~"5.."}[5m])) / sum(rate(http_request_duration_ms_count{route=~"/api/v1/.*"}[5m]))) * 100) < 99
+        for: 10m
+        labels:
+          severity: critical
+          slo: availability
+        annotations:
+          summary: "API availability dropped below 99%"
+          description: "Calculated availability for /api/v1 routes has been under 99% for 10 minutes."
+
+      - alert: Api5xxErrorRateHigh
+        expr: (sum(rate(http_request_duration_ms_count{route=~"/api/v1/.*",status_code=~"5.."}[5m])) / sum(rate(http_request_duration_ms_count{route=~"/api/v1/.*"}[5m]))) * 100 > 1
+        for: 10m
+        labels:
+          severity: warning
+          slo: error-rate
+        annotations:
+          summary: "API 5xx error rate is above 1%"
+          description: "The /api/v1 5xx error-rate exceeded 1% for 10 minutes."


### PR DESCRIPTION
## Summary
- add Grafana dashboard provisioning for API SLO visibility (availability, p95 latency, 5xx error rate, throughput)
- add Prometheus SLO alert rules and wire rule file loading in Prometheus + docker compose
- document dashboard/alert behavior and non-production validation workflow

## Test plan
- [x] npm run lint
- [x] npm test
- [x] node -e JSON.parse(require('fs').readFileSync('observability/grafana/provisioning/dashboards/api-slo-overview.json','utf8'))
- [x] docker compose config

Closes #4